### PR TITLE
🚀 Add Interactive CLI Docs with DeepGuide

### DIFF
--- a/.dg/.gitignore
+++ b/.dg/.gitignore
@@ -1,0 +1,3 @@
+# DeepGuide demo output
+.dg/casts/
+.dg/svg/

--- a/.dg/README.md
+++ b/.dg/README.md
@@ -1,0 +1,9 @@
+# DeepGuide Integration
+
+This directory holds configuration and interactive demo assets for [DeepGuide](https://github.com/deepguide/dg).
+
+To add your first demo, run:
+
+```bash
+bunx @deepguide/dg capture
+```

--- a/.dg/config.json
+++ b/.dg/config.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0",
+  "project": "scratch",
+  "casts": []
+}

--- a/.github/workflows/dg-validate.yml
+++ b/.github/workflows/dg-validate.yml
@@ -1,0 +1,10 @@
+name: Validate DeepGuide Casts
+on: [pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bunx @deepguide/dg validate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # A CLI Tool
 
+
+## Interactive CLI Demos (DeepGuide Ready!)
+
+This project is pre-configured for [DeepGuide](https://github.com/deepguide/dg) interactive terminal demos.
+
+To add your first demo:
+```bash
+bunx @deepguide/dg capture
+```
+
+Your demo will be auto-validated by CI after you push.
+
+
 ## **Test the Demo CLI**
 
 ```bash


### PR DESCRIPTION
Hi there! 👋

I noticed scratch is an actively maintained CLI tool and wanted to help make your documentation even better!

This PR sets up [DeepGuide](https://github.com/deepguide/dg)—an open-source system for recording and validating interactive terminal demos right in your README (with optional CI validation).

### **What's in this PR**
- Adds a `.dg/` directory with initial config—**no code or commands run by this PR**.
- Prepares your repo for interactive CLI demos.
- (Optional) Adds a GitHub Action workflow for future demo validation in CI.
- Updates the README with instructions for adding your first demo.

### **How to add your first interactive demo**
After merging this PR, simply run:
```bash
bunx @deepguide/dg capture
```
Then commit the generated `.cast` and `.svg` files—your README will be ready for rich, interactive terminal docs!

You can add as many demos as you want.

### **Why use DeepGuide?**
📽️ Show live, copy-pasteable CLI usage with animated/interactive demos

🟢 Keep demos up to date (self-testing with CI validation)

🚫 No more GIFs or stale code blocks

**Note:** This PR only adds the infrastructure. No code was run or executed for your repo.

If you're not interested, feel free to close—thanks for your work on this CLI! 🙏