### PR TITLE
🚀 Add Interactive CLI Docs with DeepGuide

### DIFF
--- a/.dg/.gitignore
+++ b/.dg/.gitignore
@@ -1,0 +1,3 @@
+# DeepGuide
+.dg/casts/
+.dg/svg/

--- a/.dg/README.md
+++ b/.dg/README.md
@@ -1,0 +1,9 @@
+# DeepGuide Integration
+
+This directory holds configuration and interactive demo assets for [DeepGuide](https://github.com/deepguide-ai/dg).
+
+To add your first demo, run:
+
+```bash
+npx @deepguide-ai/dg capture
+```

--- a/.dg/config.json
+++ b/.dg/config.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0",
+  "project": "scratch",
+  "casts": []
+}

--- a/.github/workflows/dg-validate.yml
+++ b/.github/workflows/dg-validate.yml
@@ -1,0 +1,28 @@
+name: DeepGuide
+
+on:
+  push:
+    branches: [ main, master, develop ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  validate:
+    name: Validate Demos
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+      
+    - name: Install asciinema
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y asciinema
+    
+    - name: Validate demos
+      run: npx @deepguide-ai/dg validate --non-interactive


### PR DESCRIPTION
Hi there! 👋

I noticed scratch is an actively maintained CLI tool and wanted to help make your documentation even better!

This PR sets up [DeepGuide](https://github.com/deepguide-ai/dg), a tool for recording and validating interactive terminal demos right in your README (with optional CI validation).

### **What's in this PR**

- a `.dg/` directory with initial config. 
- Prep your repo for capturing CLI demos.
- Adds a GitHub Action workflow for validation in CI.
- No code or functional changes to your repo.

### **How to add your first interactive demo**

After merging this PR, simply run:
```bash
npx @deepguide-ai/dg capture
```
Copy the generated markdown to README or other docs as you like. Then commit the changes. 
Your repo will be ready for rich, interactive terminal docs!

### **Why use DeepGuide?**

📽️ Easily show live, copy-pasteable usage with animated/interactive demos

🚫 No more GIFs or stale code blocks

🟢 Keep demos up to date (self-testing with CI validation)

If you're not interested, feel free to close. Thanks for your work! 🙏